### PR TITLE
Updates required after Clever API's deprecation of v1

### DIFF
--- a/test/src/Provider/CleverTest.php
+++ b/test/src/Provider/CleverTest.php
@@ -58,17 +58,20 @@ class CleverTest extends \PHPUnit_Framework_TestCase
     public function testResourceOwnerDetailsUrl()
     {
         $token = m::mock('League\OAuth2\Client\Token\AccessToken', [['access_token' => 'mock_access_token']]);
-    
+
+        $user = $this->provider->getResourceOwner($token);
+
         $url = $this->provider->getResourceOwnerDetailsUrl($token);
         $uri = parse_url($url);
+        $uriId = array_slice(explode('/', $uri['path']), 0)[3];
     
-        $this->assertEquals('/me', $uri['path']);
+        $this->assertEquals($uriId, $user->getId());
         $this->assertNotContains('mock_access_token', $url);
     }
 
     public function testUserData()
     {
-        $response = json_decode('{"type": "teacher", "data": {"id": "12345", "sis_id": "54321", "email": "mock_email", "name": {"first": "mock_first_name", "middle": "mock_middle_name", "last": "mock_last_name"}, "school": "1111122222", "district": "54545454"}}', true);
+        $response = json_decode('{"data": {"id": "12345", "sis_id": "54321", "email": "mock_email", "name": {"first": "mock_first_name", "middle": "mock_middle_name", "last": "mock_last_name"}, "school": "1111122222", "district": "54545454"}, "links": [{"rel": "self", "uri": "/v2.0/teachers/12345"}]}', true);
 
         $provider = m::mock('Schoolrunner\OAuth2\Client\Provider\Clever[fetchResourceOwnerDetails]')
             ->shouldAllowMockingProtectedMethods();
@@ -101,7 +104,7 @@ class CleverTest extends \PHPUnit_Framework_TestCase
     
     public function testUserDataUnknownUserType()
     {
-        $response = json_decode('{"type": "district_admin", "data": {"id": "12345", "sis_id": "54321", "email": "mock_email", "name": {"first": "mock_first_name", "middle": "mock_middle_name", "last": "mock_last_name"}, "school": "1111122222", "district": "54545454"}}', true);
+        $response = json_decode('{"data": {"id": "12345", "sis_id": "54321", "email": "mock_email", "name": {"first": "mock_first_name", "middle": "mock_middle_name", "last": "mock_last_name"}, "school": "1111122222", "district": "54545454"}, "links": [{"rel": "self", "uri": "/v2.0/districtadmins/12345"}]}', true);
 
         $provider = m::mock('Schoolrunner\OAuth2\Client\Provider\Clever[fetchResourceOwnerDetails]')
             ->shouldAllowMockingProtectedMethods();


### PR DESCRIPTION
Makes updates necessary after the deprecation of Clever's API v1.

1. 'https://api.clever.com/me' no longer returns user details beyond id, district, and type. We now need to make that call in our provider and pass the canonical URI that it returns as the return value of `getResourceOwnerDetailsUrl`. 
2. Using the canonical URI in the resource owner details URL does not return type. We have add some processing to grab the type string from the canonical URI in `createResourceOwner`.
3. These changes required updates to our unit tests.

@MorpheusZero @gigismint @sgenduso 